### PR TITLE
ENG-446: fix error thrown by pgpt due to unnecessary tokenizer

### DIFF
--- a/.neuro/live.yaml
+++ b/.neuro/live.yaml
@@ -68,6 +68,7 @@ jobs:
       VLLM_MODEL: meta-llama/Meta-Llama-3.1-8B-Instruct
       VLLM_TOKENIZER: meta-llama/Meta-Llama-3.1-8B-Instruct
       HUGGINGFACE_TOKEN: secret:HF_TOKEN
+      HF_HOME: /home/worker/app/models/cache
 
   vllm:
     image: vllm/vllm-openai:v0.6.1.post2

--- a/settings/settings-app.yaml
+++ b/settings/settings-app.yaml
@@ -4,7 +4,6 @@ server:
 
 llm:
   mode: openailike
-  tokenizer: ${VLLM_TOKENIZER:-}
   max_new_tokens: ${VLLM_MAX_NEW_TOKENS:5000}
   context_window: ${VLLM_CONTEXT_WINDOW:4096}
   temperature: ${VLLM_TEMPERATURE:0.1}

--- a/settings/settings-vllm-pgvector.yaml
+++ b/settings/settings-vllm-pgvector.yaml
@@ -4,7 +4,6 @@ server:
 
 llm:
   mode: openailike
-  tokenizer: ${VLLM_TOKENIZER:lmsys/vicuna-7b-v1.5}
   max_new_tokens: ${VLLM_MAX_NEW_TOKENS:5000}
   context_window: ${VLLM_CONTEXT_WINDOW:4096}
   temperature: ${VLLM_TEMPERATURE:0.1}

--- a/settings/settings.yaml
+++ b/settings/settings.yaml
@@ -39,7 +39,6 @@ llm:
   # Should be matching the selected model
   max_new_tokens: 512
   context_window: 3900
-  tokenizer: mistralai/Mistral-7B-Instruct-v0.2
   temperature: 0.1 # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
 
 rag:


### PR DESCRIPTION
# Description
Removed tokenizer from definition to as it was requested and not used in the current context and also added HF_HOME to be able to use token

We were getting this error 
`Message: 'Failed to download tokenizer %s. Falling back to default tokenizer.'`
Credits to @YevheniiSemendiak  for pointing out the reason why the error was occurring and providing a fix.

### Before
```
private-gpt-apolo) ➜  private-gpt git:(apolo) ✗ apolo-flow run pgpt
Your root certificates are out of date.
You are using certifi 2024.2.2, however 2024.8.30 is available.
Please consider upgrading certifi package, e.g.:
    python -m pip install --upgrade certifi
or
    conda update certifi
Your root certificates are out of date.
You are using certifi 2024.2.2, however 2024.8.30 is available.
Please consider upgrading certifi package, e.g.:
    python -m pip install --upgrade certifi
or
    conda update certifi
[19:50:38] Copying /Users/taddeusbuica/Desktop/work/private-gpt/settings => storage://imdc/apolo/onboarding-taddeus/private_gpt/settings                                                                                                                                         
[19:50:39] Starting copying directory /Users/taddeusbuica/Desktop/work/private-gpt/settings                                                                                                                                                                                      
           Copying: /Users/taddeusbuica/Desktop/work/private-gpt/settings/settings-vllm-pgvector.yaml                                                                                                                                                                            
           Copied: /Users/taddeusbuica/Desktop/work/private-gpt/settings/settings-vllm-pgvector.yaml                                                                                                                                                                             
           Finished copying directory /Users/taddeusbuica/Desktop/work/private-gpt/settings                                                                                                                                                                                      
Your root certificates are out of date.
You are using certifi 2024.2.2, however 2024.8.30 is available.
Please consider upgrading certifi package, e.g.:
    python -m pip install --upgrade certifi
or
    conda update certifi
√ Job ID: job-54e2a102-f99d-4d97-a6d2-12f07cbc4662
√ Name: pgpt
- Status: pending Creating
- Status: pending Scheduling
√ Status: running
√ Http URL: https://pgpt--6debb1a881.jobs.imdc.org.neu.ro
√ The job will die in 5 days. See --life-span option documentation for details.
Browsing job, please open: https://pgpt--6debb1a881.jobs.imdc.org.neu.ro
√ =========== Job is running in terminal mode ===========
√ (If you don't see a command prompt, try pressing enter)
√ (Use Ctrl-P Ctrl-Q key sequence to detach from the job)
17:50:43.884 [INFO    ] private_gpt.settings.settings_loader - Starting application with profiles=['default', 'vllm-pgvector']
√ ========= Job's output, may overlap with logs =========
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
17:50:50.358 [WARNING ]                matplotlib - Matplotlib created a temporary cache directory at /tmp/matplotlib-4xmcj8um because the default path (/nonexistent/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
17:50:50.583 [INFO    ]   matplotlib.font_manager - generated new fontManager
--- Logging error ---
Traceback (most recent call last):
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 798, in get
    return self._context[key]
           ~~~~~~~~~~~~~^^^^^
KeyError: <class 'private_gpt.ui.ui.PrivateGptUi'>
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 798, in get
    return self._context[key]
           ~~~~~~~~~~~~~^^^^^
KeyError: <class 'private_gpt.server.ingest.ingest_service.IngestService'>
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 798, in get
    return self._context[key]
           ~~~~~~~~~~~~~^^^^^
KeyError: <class 'private_gpt.components.llm.llm_component.LLMComponent'>
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_errors.py", line 270, in hf_raise_for_status
    response.raise_for_status()
  File "/home/worker/app/.venv/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/resolve/main/config.json
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/utils/hub.py", line 398, in cached_file
    resolved_file = hf_hub_download(
                    ^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 118, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py", line 1374, in hf_hub_download
    raise head_call_error
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py", line 1247, in hf_hub_download
    metadata = get_hf_file_metadata(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 118, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py", line 1624, in get_hf_file_metadata
    r = _request_wrapper(
        ^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py", line 402, in _request_wrapper
    response = _request_wrapper(
               ^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py", line 426, in _request_wrapper
    hf_raise_for_status(response)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_errors.py", line 286, in hf_raise_for_status
    raise GatedRepoError(message, response) from e
huggingface_hub.utils._errors.GatedRepoError: 403 Client Error. (Request ID: Root=1-672a5afb-42f61a6d09b6a59f1c496e39;b33f8b20-6cae-49a8-b9af-e075996dbd1f)
Cannot access gated repo for url https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/resolve/main/config.json.
Access to model mistralai/Mistral-7B-Instruct-v0.2 is restricted and you are not in the authorized list. Visit https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2 to ask for access.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/worker/app/private_gpt/components/llm/llm_component.py", line 30, in __init__
    AutoTokenizer.from_pretrained(
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/models/auto/tokenization_auto.py", line 782, in from_pretrained
    config = AutoConfig.from_pretrained(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/models/auto/configuration_auto.py", line 1111, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/configuration_utils.py", line 633, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/configuration_utils.py", line 688, in _get_config_dict
    resolved_config_file = cached_file(
                           ^^^^^^^^^^^^
  File "/home/worker/app/.venv/lib/python3.11/site-packages/transformers/utils/hub.py", line 416, in cached_file
    raise EnvironmentError(
OSError: You are trying to access a gated repo.
Make sure to have access to it at https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2.
403 Client Error. (Request ID: Root=1-672a5afb-42f61a6d09b6a59f1c496e39;b33f8b20-6cae-49a8-b9af-e075996dbd1f)
Cannot access gated repo for url https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/resolve/main/config.json.
Access to model mistralai/Mistral-7B-Instruct-v0.2 is restricted and you are not in the authorized list. Visit https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2 to ask for access.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/worker/app/private_gpt/__main__.py", line 5, in <module>
    from private_gpt.main import app
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/worker/app/private_gpt/main.py", line 6, in <module>
    app = create_app(global_injector)
  File "/home/worker/app/private_gpt/launcher.py", line 63, in create_app
    ui = root_injector.get(PrivateGptUi)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 974, in get
    provider_instance = scope_instance.get(interface, binding.provider)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 800, in get
    instance = self._get_instance(key, provider, self.injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 811, in _get_instance
    return provider.get(injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 264, in get
    return injector.create_object(self._cls)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 998, in create_object
    self.call_with_injection(init, self_=instance, kwargs=additional_kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 1031, in call_with_injection
    dependencies = self.args_to_inject(
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 1079, in args_to_inject
    instance: Any = self.get(interface)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 974, in get
    provider_instance = scope_instance.get(interface, binding.provider)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 800, in get
    instance = self._get_instance(key, provider, self.injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 811, in _get_instance
    return provider.get(injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 264, in get
    return injector.create_object(self._cls)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 998, in create_object
    self.call_with_injection(init, self_=instance, kwargs=additional_kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 1031, in call_with_injection
    dependencies = self.args_to_inject(
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 1079, in args_to_inject
    instance: Any = self.get(interface)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 974, in get
    provider_instance = scope_instance.get(interface, binding.provider)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 91, in wrapper
    return function(*args, **kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 800, in get
    instance = self._get_instance(key, provider, self.injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 811, in _get_instance
    return provider.get(injector)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 264, in get
    return injector.create_object(self._cls)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 998, in create_object
    self.call_with_injection(init, self_=instance, kwargs=additional_kwargs)
  File "/home/worker/app/.venv/lib/python3.11/site-packages/injector/__init__.py", line 1040, in call_with_injection
    return callable(*full_args, **dependencies)
  File "/home/worker/app/private_gpt/components/llm/llm_component.py", line 37, in __init__
    logger.warning(
Message: 'Failed to download tokenizer %s. Falling back to default tokenizer.'
Arguments: ('mistralai/Mistral-7B-Instruct-v0.2', OSError('You are trying to access a gated repo.\nMake sure to have access to it at https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2.\n403 Client Error. (Request ID: Root=1-672a5afb-42f61a6d09b6a59f1c496e39;b33f8b20-6cae-49a8-b9af-e075996dbd1f)\n\nCannot access gated repo for url https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/resolve/main/config.json.\nAccess to model mistralai/Mistral-7B-Instruct-v0.2 is restricted and you are not in the authorized list. Visit https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2 to ask for access.'))
17:50:51.794 [INFO    ] private_gpt.components.llm.llm_component - Initializing the LLM in mode=openailike
17:50:52.166 [INFO    ] private_gpt.components.embedding.embedding_component - Initializing the embedding model in mode=ollama
17:50:52.174 [INFO    ] llama_index.core.indices.loading - Loading all indices.
17:50:52.897 [INFO    ]         private_gpt.ui.ui - Mounting the gradio UI, at path=/
17:50:52.958 [INFO    ]             uvicorn.error - Started server process [7]
17:50:52.958 [INFO    ]             uvicorn.error - Waiting for application startup.
17:50:52.959 [INFO    ]             uvicorn.error - Application startup complete.
17:50:52.959 [INFO    ]             uvicorn.error - Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

### After
```
8:25:39.160 [INFO ] private_gpt.settings.settings_loader - Starting application with profiles=['default', 'vllm-pgvector']
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
08:25:45.473 [WARNING ] matplotlib - Matplotlib created a temporary cache directory at /tmp/matplotlib-u10esbds because the default path (/nonexistent/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
08:25:45.695 [INFO ] matplotlib.font_manager - generated new fontManager
08:25:46.670 [INFO ] private_gpt.components.llm.llm_component - Initializing the LLM in mode=openailike
08:25:47.028 [INFO ] private_gpt.components.embedding.embedding_component - Initializing the embedding model in mode=ollama
08:25:47.036 [INFO ] llama_index.core.indices.loading - Loading all indices.
08:25:47.725 [INFO ] private_gpt.ui.ui - Mounting the gradio UI, at path=/
08:25:47.785 [INFO ] uvicorn.error - Started server process [7]
08:25:47.785 [INFO ] uvicorn.error - Waiting for application startup.
08:25:47.785 [INFO ] uvicorn.error - Application startup complete.
08:25:47.785 [INFO ] uvicorn.error - Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran `make check; make test` to ensure mypy and tests pass