### PR TITLE
Added auto pr from upstream workflow

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,16 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
+    with:
+      upstream_repository: https://github.com/zylon-ai/private-gpt
+      upstream_tag_regex: 'v\d+\..*'
+    secrets:
+      personal_access_token: ${{ secrets.AUTO_PR_PAT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of creating pull requests for updates from an upstream repository. The most important change is the addition of the `auto-pr.yml` file which defines the workflow.

Automation of upstream updates:

* [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1R1-R16): Added a new workflow named "Upstream to PR" that runs on a schedule and can also be manually triggered. It uses the `neuro-inc/reuse` action to create pull requests from the upstream repository `https://github.com/zylon-ai/private-gpt` based on the specified tag regex and uses a personal access token stored in secrets.